### PR TITLE
Change poll loop so task can shut down gracefully

### DIFF
--- a/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceTask.java
@@ -72,27 +72,18 @@ public class TwitterSourceTask extends SourceTask implements StatusListener {
   }
 
   @Override
-  public List<SourceRecord> poll() throws InterruptedException {
-    List<SourceRecord> records = new ArrayList<>(256);
-
-    while (records.isEmpty()) {
-      int size = messageQueue.size();
-
-      for (int i = 0; i < size; i++) {
-        SourceRecord record = this.messageQueue.poll();
-
-        if (null == record) {
-          break;
-        }
-
-        records.add(record);
+  public List<SourceRecord> poll() {
+    final int maxPollRecords = 256;
+    List<SourceRecord> records = new ArrayList<>(maxPollRecords);
+    SourceRecord record = messageQueue.poll();
+    while (record != null) {
+      records.add(record);
+      if (records.size() >= maxPollRecords) {
+        break;
       }
-
-      if (records.isEmpty()) {
-        Thread.sleep(100);
-      }
+      record = messageQueue.poll();
     }
-
+    log.debug("Took {} records from the message queue.", records.size());
     return records;
   }
 


### PR DESCRIPTION
#### Background information

The polling mechanism of the source task can get into a kind of a livelock situation, where it continually checks for messages, sleeps, and then checks again… for as long as the queue is empty.

Meanwhile, when a worker has been stopped by Kafka Connect for any reason (such as a worker group rebalance), the queue will no longer receive updates and so remains empty indefinitely. This has the result that the polling loop never exits—at least, not until the graceful shutdown timeout is exceeded.

The poll does support the throwing of InterruptExceptions, which _would_ exit the loop. However, thread interrupts do not appear to be Kafka Connect's approach to stopping its tasks. Instead, when a worker shuts down, it simply ceases to make any new calls to the task poll. Any existing poll is waited upon to complete.

#### Implementation summary

This change modifies the source task's poll loop, so that the Kafka Connect framework will be responsible for retrying it, in cases where no new records are immediately available. Now it simply exits when either the source queue is empty or it has pulled a maximum number of messages.

#### Before & after

The source task will now stop normally so that, when the connector shuts down, it will no longer take the entire `task.shutdown.graceful.timeout.ms` duration only to terminate with a `Graceful stop of task twitter-source-0 failed.`