### PR TITLE
Change the Twitter API call to follow a UserId set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ twitter.oauth.consumerKey=
 | Name                            | Description                                       | Type     | Default | Valid Values | Importance |
 |---------------------------------|---------------------------------------------------|----------|---------|--------------|------------|
 | filter.keywords                 | Twitter keywords to filter for.                   | list     |         |              | high       |
+| filter.userIds                  | Twitter user IDs to follow.                       | list     | ""      |              | low        |
 | kafka.delete.topic              | Kafka topic to write delete events to.            | string   |         |              | high       |
 | kafka.status.topic              | Kafka topic to write the statuses to.             | string   |         |              | high       |
 | process.deletes                 | Should this connector process deletes.            | boolean  |         |              | high       |

--- a/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceConnectorConfig.java
@@ -23,7 +23,6 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import twitter4j.conf.Configuration;
 import twitter4j.conf.PropertyConfiguration;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -73,7 +72,7 @@ public class TwitterSourceConnectorConfig extends AbstractConfig {
         .define(TWITTER_OAUTH_ACCESS_TOKEN_CONF, Type.PASSWORD, Importance.HIGH, TWITTER_OAUTH_ACCESS_TOKEN_DOC)
         .define(TWITTER_OAUTH_ACCESS_TOKEN_SECRET_CONF, Type.PASSWORD, Importance.HIGH, TWITTER_OAUTH_ACCESS_TOKEN_SECRET_DOC)
         .define(FILTER_KEYWORDS_CONF, Type.LIST, Importance.HIGH, FILTER_KEYWORDS_DOC)
-        .define(FILTER_USER_IDS_CONF, Type.LIST, Collections.EMPTY_SET, Importance.LOW, FILTER_USER_IDS_DOC)
+        .define(FILTER_USER_IDS_CONF, Type.LIST, "", Importance.LOW, FILTER_USER_IDS_DOC)
         .define(KAFKA_STATUS_TOPIC_CONF, Type.STRING, Importance.HIGH, KAFKA_STATUS_TOPIC_DOC)
         .define(PROCESS_DELETES_CONF, Type.BOOLEAN, Importance.HIGH, PROCESS_DELETES_DOC);
   }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceConnectorConfig.java
@@ -36,6 +36,7 @@ public class TwitterSourceConnectorConfig extends AbstractConfig {
   public static final String TWITTER_OAUTH_ACCESS_TOKEN_CONF = "twitter.oauth.accessToken";
   public static final String TWITTER_OAUTH_ACCESS_TOKEN_SECRET_CONF = "twitter.oauth.accessTokenSecret";
   public static final String FILTER_KEYWORDS_CONF = "filter.keywords";
+  public static final String FILTER_USER_IDS_CONF = "filter.userIds";
   public static final String KAFKA_STATUS_TOPIC_CONF = "kafka.status.topic";
   public static final String KAFKA_STATUS_TOPIC_DOC = "Kafka topic to write the statuses to.";
   public static final String PROCESS_DELETES_CONF = "process.deletes";
@@ -46,11 +47,13 @@ public class TwitterSourceConnectorConfig extends AbstractConfig {
   private static final String TWITTER_OAUTH_ACCESS_TOKEN_DOC = "OAuth access token";
   private static final String TWITTER_OAUTH_ACCESS_TOKEN_SECRET_DOC = "OAuth access token secret";
   private static final String FILTER_KEYWORDS_DOC = "Twitter keywords to filter for.";
+  private static final String FILTER_USER_IDS_DOC = "Twitter user IDs to follow.";
 
   public final String topic;
   public final boolean twitterDebug;
   public final boolean processDeletes;
   public final Set<String> filterKeywords;
+  public final Set<String> filterUserIds;
 
   public TwitterSourceConnectorConfig(Map<String, String> parsedConfig) {
     super(conf(), parsedConfig);
@@ -58,6 +61,7 @@ public class TwitterSourceConnectorConfig extends AbstractConfig {
     this.twitterDebug = this.getBoolean(TWITTER_DEBUG_CONF);
     this.processDeletes = this.getBoolean(PROCESS_DELETES_CONF);
     this.filterKeywords = ConfigUtils.getSet(this, FILTER_KEYWORDS_CONF);
+    this.filterUserIds = ConfigUtils.getSet(this, FILTER_USER_IDS_CONF);
   }
 
   public static ConfigDef conf() {
@@ -68,6 +72,7 @@ public class TwitterSourceConnectorConfig extends AbstractConfig {
         .define(TWITTER_OAUTH_ACCESS_TOKEN_CONF, Type.PASSWORD, Importance.HIGH, TWITTER_OAUTH_ACCESS_TOKEN_DOC)
         .define(TWITTER_OAUTH_ACCESS_TOKEN_SECRET_CONF, Type.PASSWORD, Importance.HIGH, TWITTER_OAUTH_ACCESS_TOKEN_SECRET_DOC)
         .define(FILTER_KEYWORDS_CONF, Type.LIST, Importance.HIGH, FILTER_KEYWORDS_DOC)
+        .define(FILTER_USER_IDS_CONF, Type.LIST, Importance.HIGH, FILTER_USER_IDS_DOC)
         .define(KAFKA_STATUS_TOPIC_CONF, Type.STRING, Importance.HIGH, KAFKA_STATUS_TOPIC_DOC)
         .define(PROCESS_DELETES_CONF, Type.BOOLEAN, Importance.HIGH, PROCESS_DELETES_DOC);
   }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceConnectorConfig.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceConnectorConfig.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import twitter4j.conf.Configuration;
 import twitter4j.conf.PropertyConfiguration;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -72,7 +73,7 @@ public class TwitterSourceConnectorConfig extends AbstractConfig {
         .define(TWITTER_OAUTH_ACCESS_TOKEN_CONF, Type.PASSWORD, Importance.HIGH, TWITTER_OAUTH_ACCESS_TOKEN_DOC)
         .define(TWITTER_OAUTH_ACCESS_TOKEN_SECRET_CONF, Type.PASSWORD, Importance.HIGH, TWITTER_OAUTH_ACCESS_TOKEN_SECRET_DOC)
         .define(FILTER_KEYWORDS_CONF, Type.LIST, Importance.HIGH, FILTER_KEYWORDS_DOC)
-        .define(FILTER_USER_IDS_CONF, Type.LIST, Importance.HIGH, FILTER_USER_IDS_DOC)
+        .define(FILTER_USER_IDS_CONF, Type.LIST, Collections.EMPTY_SET, Importance.LOW, FILTER_USER_IDS_DOC)
         .define(KAFKA_STATUS_TOPIC_CONF, Type.STRING, Importance.HIGH, KAFKA_STATUS_TOPIC_DOC)
         .define(PROCESS_DELETES_CONF, Type.BOOLEAN, Importance.HIGH, PROCESS_DELETES_DOC);
   }

--- a/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceTask.java
+++ b/src/main/java/com/github/jcustenborder/kafka/connect/twitter/TwitterSourceTask.java
@@ -55,7 +55,8 @@ public class TwitterSourceTask extends SourceTask implements StatusListener {
     TwitterStreamFactory twitterStreamFactory = new TwitterStreamFactory(this.config.configuration());
     this.twitterStream = twitterStreamFactory.getInstance();
 
-    String[] keywords = this.config.filterKeywords.toArray(new String[0]);
+    String[] keywords = config.filterKeywords.toArray(new String[0]);
+    long[] userIds = config.filterUserIds.stream().mapToLong(Long::valueOf).toArray();
 
     if (log.isInfoEnabled()) {
       log.info("Setting up filters. Keywords = {}", Joiner.on(", ").join(keywords));
@@ -63,6 +64,7 @@ public class TwitterSourceTask extends SourceTask implements StatusListener {
 
     FilterQuery filterQuery = new FilterQuery();
     filterQuery.track(keywords);
+    filterQuery.follow(userIds);
 
     if (log.isInfoEnabled()) {
       log.info("Starting the twitter stream.");


### PR DESCRIPTION
#### Background information
For the use case of tracking a user's tweets/replies/mentions, the `filter.keywords` property can be exploited to scan for tweets containing the user's Twitter handle. This is supported by the ["track" request paramater][filter-realtime-tweets] of the API endpoint, and can sometimes perform acceptably for mentions and replies.

But to select for a user's tweets themselves, only in the rare case that a user's tweet contains their own username will it be captured—since the matching keywords must appear somewhere in the tweet body. Otherwise, the connector currently has no way of tracking tweets originating from a given account.

However, the API also provides us with a `follow` request parameter (see the doc referred to above), which can bring to bear the desired tweets.

#### Implementation summary
- Add a configuration option that is a set (maybe empty) of Twitter UserId values to follow
- Add the UserId set to the `FilterQuery` via its `follow` method

#### Before & after
After this change, the `filter.userIds` property, a comma-separated list of UserId values will be allowed (which could be an empty string, which is the default), and if specified will allow the connector to follow tweets originating from, replying to, or mentioning the listed users.

In addition, the connector will continue to track all other tweets that contain any specified filter keywords in their text.

[filter-realtime-tweets]: https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters.html
